### PR TITLE
Add examples to README.

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -37,6 +37,63 @@ remotes::install_github("r4ds/scenes")
 
 You can see a demonstration of {scenes} [here](https://r4ds.io/scenesdemo).
 
+## Use Cases
+
+Some examples of how you might use {scenes} to switch between different UIs in a Shiny app:
+
+- **Login Wrapper**: Use {scenes} to switch between a login page and the main content of the app. This is the original use case for {scenes}. It ws designed to abstract the login-wrapper concept implemented in [{shinyslack}](https://github.com/r4ds/shinyslack).
+
+- **App Modes**: Use {scenes} to switch between different modes of the app, such as a view-only mode and an edit mode, via a query parameter (`yourapp.shinyapps.io?mode=edit`). 
+
+- **User Roles**: Use {scenes} to switch between different UIs based on user roles. For example, a non-admin user might see a different UI than an admin user.
+
+The **Login Wrapper** example might look like this:
+
+```{r login-wrapper, eval = FALSE}
+library(shiny)
+library(scenes)
+
+# Define the different scenes for the app
+login_ui <- fluidPage(
+  textInput("username", "Username"),
+  passwordInput("password", "Password"),
+  actionButton("login", "Login")
+)
+
+main_ui <- fluidPage(
+  h1("Welcome"),
+  textOutput("username")
+)
+
+# Use the `set_scene()` function to define the different scenes, and
+# `change_scene()` to switch between them.
+ui <- change_scene(
+  set_scene(
+    main_ui,
+    req_has_cookie(
+      "validate_login",
+      validation_fn = my_validation_fn
+    )
+  ),
+  fall_through = login_ui
+)
+
+server <- function(input, output, session) {
+  observeEvent(input$login, {
+    use_cookies_package_to_save_cookie_fn(input$username, input$password)
+  })
+
+  output$username <- renderText({
+    input$username
+  })
+}
+
+shinyApp(ui = ui, server = server)
+
+```
+
+See [{shinyslack}](https://github.com/r4ds/shinyslack) for a fully implemented example.
+
 ## Similar Packages
 
 Other packages have implemented features in this domain.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,71 @@ remotes::install_github("r4ds/scenes")
 You can see a demonstration of {scenes}
 [here](https://r4ds.io/scenesdemo).
 
+## Use Cases
+
+Some examples of how you might use {scenes} to switch between different
+UIs in a Shiny app:
+
+- **Login Wrapper**: Use {scenes} to switch between a login page and the
+  main content of the app. This is the original use case for {scenes}.
+  It ws designed to abstract the login-wrapper concept implemented in
+  [{shinyslack}](https://github.com/r4ds/shinyslack).
+
+- **App Modes**: Use {scenes} to switch between different modes of the
+  app, such as a view-only mode and an edit mode, via a query parameter
+  (`yourapp.shinyapps.io?mode=edit`).
+
+- **User Roles**: Use {scenes} to switch between different UIs based on
+  user roles. For example, a non-admin user might see a different UI
+  than an admin user.
+
+The **Login Wrapper** example might look like this:
+
+``` r
+library(shiny)
+library(scenes)
+
+# Define the different scenes for the app
+login_ui <- fluidPage(
+  textInput("username", "Username"),
+  passwordInput("password", "Password"),
+  actionButton("login", "Login")
+)
+
+main_ui <- fluidPage(
+  h1("Welcome"),
+  textOutput("username")
+)
+
+# Use the `set_scene()` function to define the different scenes, and
+# `change_scene()` to switch between them.
+ui <- change_scene(
+  set_scene(
+    main_ui,
+    req_has_cookie(
+      "validate_login",
+      validation_fn = my_validation_fn
+    )
+  ),
+  fall_through = login_ui
+)
+
+server <- function(input, output, session) {
+  observeEvent(input$login, {
+    use_cookies_package_to_save_cookie_fn(input$username, input$password)
+  })
+
+  output$username <- renderText({
+    input$username
+  })
+}
+
+shinyApp(ui = ui, server = server)
+```
+
+See [{shinyslack}](https://github.com/r4ds/shinyslack) for a fully
+implemented example.
+
 ## Similar Packages
 
 Other packages have implemented features in this domain.


### PR DESCRIPTION
Closes #48.

This was implemented with the help of chatGPT. The weird thing is I swear I wrote these examples somewhere. Maybe in an older version of the README?